### PR TITLE
Separate Chrome install

### DIFF
--- a/app/lib/Navigator.js
+++ b/app/lib/Navigator.js
@@ -9,7 +9,8 @@ class Navigator
 		this.blocklist = null;
 		this.browserPromise = null;
 		this.defaultPuppeteerOptions = {
-			args: ['--no-sandbox'],
+			executablePath: 'google-chrome-unstable',
+			args: ['--no-sandbox', '--disable-dev-shm-usage'],
 			defaultViewport: {
 				width: 1920,
 				height: 1080

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,66 +1,37 @@
 FROM node:10-slim
 
-RUN apt-get update && apt-get install -yq \
-	gconf-service \
-	libasound2 \
-	libatk1.0-0 \
-	libc6 \
-	libcairo2 \
-	libcups2 \
-	libdbus-1-3 \
-	libexpat1 \
-	libfontconfig1 \
-	libgcc1 \
-	libgconf-2-4 \
-	libgdk-pixbuf2.0-0 \
-	libglib2.0-0 \
-	libgtk-3-0 \
-	libnspr4 \
-	libpango-1.0-0 \
-	libpangocairo-1.0-0 \
-	libstdc++6 \
-	libx11-6 \
-	libx11-xcb1 \
-	libxcb1 \
-	libxcomposite1 \
-	libxcursor1 \
-	libxdamage1 \
-	libxext6 \
-	libxfixes3 \
-	libxi6 \
-	libxrandr2 \
-	libxrender1 \
-	libxss1 \
-	libxtst6 \
-	fonts-ipafont-gothic \
-	fonts-wqy-zenhei \
-	fonts-thai-tlwg \
-	fonts-kacst \
-	ttf-freefont \
-	ca-certificates \
-	fonts-liberation \
-	libappindicator1 \
-	libnss3 \
-	lsb-release \
-	xdg-utils \
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y \
+    google-chrome-unstable \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+    fonts-thai-tlwg \
+    fonts-kacst \
+    ttf-freefont \
 	wget \
 	gnupg \
 	dirmngr \
 	python \
 	build-essential \
-	&& wget https://github.com/Yelp/dumb-init/releases/download/v1.2.1/dumb-init_1.2.1_amd64.deb \
-	&& dpkg -i dumb-init_*.deb \
-	&& rm -f dumb-init_*.deb \
-	&& apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /src/*.deb \
+    && apt-get clean && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
-#RUN groupadd --gid 1001 pptruser \
-#	&& useradd --uid 1001 --gid pptruser --groups audio,video --shell /bin/bash --create-home pptruser
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
+RUN chmod +x /usr/local/bin/dumb-init
 
-RUN mkdir -p /home/pptruser
-RUN groupadd -r pptruser && useradd -d /home/pptruser -r -g pptruser -G audio,video pptruser
-RUN chown -R pptruser:pptruser /home/pptruser
+# Use installed chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 
-RUN yarn global add nodemon puppeteer@1.14.0 && yarn cache clean
+RUN yarn global add nodemon puppeteer@1.14.0 \
+    && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser
+
+RUN wget https://raw.githubusercontent.com/jfrazelle/dotfiles/master/etc/docker/seccomp/chrome.json -O /home/pptruser/chrome.json
 
 ENV NODE_PATH="/usr/local/share/.config/yarn/global/node_modules:${NODE_PATH}"
 


### PR DESCRIPTION
Separate Chrome install in Docker container.
Makes it possible to deprecate `--no-sandbox`. Still no luck running Chrome in a sandbox without elevated privileges.