### PR TITLE
Brandr bugfixes after upgrade

### DIFF
--- a/app/lib/Extractor.js
+++ b/app/lib/Extractor.js
@@ -86,6 +86,7 @@ export default class Extractor {
 		// ]));
 	}
 
+	/** @param {AbstractStrategy} extractor */
 	registerExtractor(extractor) {
 		this.extractors[extractor.constructor.getId()] = extractor;
 	}
@@ -150,7 +151,7 @@ export default class Extractor {
 			let extractor = this.extractors[groupName];
 
 			for (let filePath of extractor.getParserFilesToInject()) {
-				if (addedScripts.indexOf(filePath) === -1) {
+				if (!addedScripts.includes(filePath)) {
 					await page.addScriptTag({path: filePath});
 					addedScripts.push(filePath);
 				}

--- a/app/lib/extractors/AbstractStrategy.js
+++ b/app/lib/extractors/AbstractStrategy.js
@@ -47,7 +47,7 @@ export default class AbstractStrategy {
 			result.origin = response.url || src;
 		}
 
-		const imageInfo = imageType(result.buffer);
+		const imageInfo = await imageType(result.buffer);
 
 		if (imageInfo) {
 			switch (imageInfo.ext) {
@@ -75,7 +75,7 @@ export default class AbstractStrategy {
 				default:
 					return null;
 			}
-		} else if (isSvg(result.buffer) === true) {
+		} else if (isSvg(result.buffer.toString()) === true) {
 			result.extension = "svg";
 		} else {
 			return null;
@@ -84,12 +84,11 @@ export default class AbstractStrategy {
 		return result;
 	}
 
+	/** @param {string} svg */
 	async parseSvg(svg) {
-		let buffer = Buffer.from(svg);
-
-		if (isSvg(buffer) === true) {
+		if (isSvg(svg)) {
 			return {
-				buffer: buffer,
+				buffer: Buffer.from(svg),
 				extension: "svg",
 				origin: "[inline]",
 			};
@@ -101,7 +100,7 @@ export default class AbstractStrategy {
 	async parseIco(icoBuffer) {
 		try {
 			let pngBuffer = await icoToPng(icoBuffer, 1024);
-			let imageInfo = imageType(pngBuffer);
+			let imageInfo = await imageType(pngBuffer);
 
 			return (imageInfo.ext === "png") ? pngBuffer : null;
 		} catch (e) {

--- a/app/lib/extractors/dom-logo/DomLogoStrategy.js
+++ b/app/lib/extractors/dom-logo/DomLogoStrategy.js
@@ -11,7 +11,9 @@ export default class DomLogoStrategy extends AbstractStrategy {
 	}
 
 	getParserFilesToInject() {
-		return [dirname + '/DomLogoStrategyParser.js'];
+		return [
+			path.normalize(dirname + '/DomLogoStrategyParser.js')
+		];
 	}
 
 	async handlePage(page, cdp) {

--- a/app/lib/extractors/facebook-logo/FacebookLogoStrategy.js
+++ b/app/lib/extractors/facebook-logo/FacebookLogoStrategy.js
@@ -12,8 +12,8 @@ export default class FacebookLogoStrategy extends AbstractStrategy {
 
 	getParserFilesToInject() {
 		return [
-			dirname + "/../AbstractMetaExtractorParser.js",
-			dirname + "/FacebookLogoStrategyParser.js",
+			path.normalize(dirname + "/../AbstractMetaExtractorParser.js"),
+			path.normalize(dirname + "/FacebookLogoStrategyParser.js"),
 		];
 	}
 

--- a/app/lib/extractors/meta-logo/MetaLogoStrategy.js
+++ b/app/lib/extractors/meta-logo/MetaLogoStrategy.js
@@ -12,8 +12,8 @@ export default class MetaLogoStrategy extends AbstractStrategy {
 
 	getParserFilesToInject() {
 		return [
-			dirname + "/../AbstractMetaExtractorParser.js",
-			dirname + "/MetaLogoStrategyParser.js",
+			path.normalize(dirname + "/../AbstractMetaExtractorParser.js"),
+			path.normalize(dirname + "/MetaLogoStrategyParser.js"),
 		];
 	}
 

--- a/app/lib/extractors/style-colors/StyleColorsStrategy.js
+++ b/app/lib/extractors/style-colors/StyleColorsStrategy.js
@@ -11,12 +11,13 @@ export default class StyleColorsStrategy extends AbstractStrategy {
 	}
 
 	getParserFilesToInject() {
-		return [dirname + "/StyleColorsStrategyParser.js"];
+		return [
+			path.normalize(dirname + "/StyleColorsStrategyParser.js")
+		];
 	}
 
 	/**
 	 * This method is executed in the context of the Headless Chrome Browser
-	 * @returns {Array}
 	 */
 	parsePage() {
 		let parser = new StyleColorsStrategyParser();

--- a/app/lib/extractors/twitter-logo/TwitterLogoStrategy.js
+++ b/app/lib/extractors/twitter-logo/TwitterLogoStrategy.js
@@ -12,8 +12,8 @@ export default class TwitterLogoStrategy extends AbstractStrategy {
 
 	getParserFilesToInject() {
 		return [
-			dirname + "/../AbstractMetaExtractorParser.js",
-			dirname + "/TwitterLogoStrategyParser.js",
+			path.normalize(dirname + "/../AbstractMetaExtractorParser.js"),
+			path.normalize(dirname + "/TwitterLogoStrategyParser.js"),
 		];
 	}
 


### PR DESCRIPTION
Brandr bugfixes after upgrade

- normalize paths so relative paths to the same file are seen as equal
- Add missing await
- isSvg() wants a string not a buffer